### PR TITLE
Fix build on linux ARM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,6 @@ SIGUSR2
 
 Notes:
 ===
-Have to install `libfile-which-perl` on Raspbian.
+Have to install `libfile-which-perl` on Debian.
+Have to install `uuid-runtime` on Debian.
 Have to install 'sudo yum install perl-File-Which' in RedHat.

--- a/hal/unix_hal.c
+++ b/hal/unix_hal.c
@@ -493,7 +493,7 @@ TIME HalGetTime()
 //IRQ Management
 //
 
-#define SIGNAL_HACK
+#undef SIGNAL_HACK
 
 #ifdef DEBUG
 #ifdef LINUX
@@ -535,7 +535,8 @@ sigset_t sigset_not(sigset_t a) {
 	sigset_t result;
 	status = sigemptyset(&result);
 	CHECK(status == 0);
-        for (i=1; i <= SIGRTMIN-1; i++) {
+	int end = SIGRTMIN-2;
+        for (i=1; i < end; i++) {
                 status = sigismember(&a, i);
                 if (status == 0) {
                   //Not set, so set in result.

--- a/hal/unix_hal.c
+++ b/hal/unix_hal.c
@@ -535,7 +535,7 @@ sigset_t sigset_not(sigset_t a) {
 	sigset_t result;
 	status = sigemptyset(&result);
 	CHECK(status == 0);
-        for (i=1; i <= __SIGRTMAX; i++) {
+        for (i=SIGRTMIN; i <= SIGRTMAX; i++) {
                 status = sigismember(&a, i);
                 if (status == 0) {
                   //Not set, so set in result.

--- a/hal/unix_hal.c
+++ b/hal/unix_hal.c
@@ -535,7 +535,7 @@ sigset_t sigset_not(sigset_t a) {
 	sigset_t result;
 	status = sigemptyset(&result);
 	CHECK(status == 0);
-        for (i=SIGRTMIN; i <= SIGRTMAX; i++) {
+        for (i=1; i <= SIGRTMAX; i++) {
                 status = sigismember(&a, i);
                 if (status == 0) {
                   //Not set, so set in result.

--- a/hal/unix_hal.c
+++ b/hal/unix_hal.c
@@ -500,14 +500,13 @@ TIME HalGetTime()
 _Bool HalIsIrqAtomic(enum IRQ_LEVEL level)
 {
         sigset_t fullSet, levelSet, curSet;
-        int status;
 
-        status = sigfillset(&fullSet);
-        ASSERT(status == 0);
+        CHECK(0 == sigfillset(&fullSet));
         levelSet = HalIrqToSigaction[level].sa_mask;
-        status = sigprocmask(0, NULL, &curSet);
-        ASSERT(status == 0);
+        CHECK(0 == sigprocmask(0, NULL, &curSet));
 
+        /* If a signal is blocked in the IRQ level, it must be blocked in the current mask.
+         * otherwise we could recieve an interrupt which breaks atomicity. */
         for (int sig = 1; sigismember(&fullSet, sig); sig++) {
           if (sigismember(&levelSet, sig) && !sigismember(&curSet, sig)) {
             return false;

--- a/hal/unix_hal.c
+++ b/hal/unix_hal.c
@@ -577,15 +577,15 @@ _Bool sigset_empty(sigset_t a) {
  */
 _Bool HalIsIrqAtomic(enum IRQ_LEVEL level)
 {
-        sigset_t curSet;
+        sigset_t levelSet, curSet;
         int status;
 
+        levelSet = HalIrqToSigaction[level].sa_mask;
         status = sigprocmask(0, NULL, &curSet);
         ASSERT(status == 0);
 
         HalUpdateIsrDebugInfo();
-
-        return sigset_empty(sigset_and(sigset_xor(HalIrqToSigaction[level].sa_mask,curSet), HalIrqToSigaction[level].sa_mask));
+        return sigset_empty(sigset_and(sigset_xor(levelSet, curSet), levelSet));
 }
 #endif //DEBUG
 

--- a/hal/unix_hal.c
+++ b/hal/unix_hal.c
@@ -493,7 +493,7 @@ TIME HalGetTime()
 //IRQ Management
 //
 
-#undef SIGNAL_HACK
+#define SIGNAL_HACK
 
 #ifdef DEBUG
 #ifdef LINUX

--- a/hal/unix_hal.c
+++ b/hal/unix_hal.c
@@ -535,7 +535,7 @@ sigset_t sigset_not(sigset_t a) {
 	sigset_t result;
 	status = sigemptyset(&result);
 	CHECK(status == 0);
-        for (i=1; i <= SIGRTMAX; i++) {
+        for (i=1; i <= SIGRTMIN-1; i++) {
                 status = sigismember(&a, i);
                 if (status == 0) {
                   //Not set, so set in result.

--- a/perf
+++ b/perf
@@ -104,5 +104,5 @@ exit($status);
 
 sub runtest {
   my $test_name = shift @_;
-  exec "./perf.py", "--timeout=$timeout", $coredir, $jobid, $branch, $commit, $dirty_str, $test_name;
+  exec "./perf.py", "--timeout=$timeout", "--debugger=$debugger", $coredir, $jobid, $branch, $commit, $dirty_str, $test_name;
 }

--- a/perf.py
+++ b/perf.py
@@ -12,6 +12,7 @@ parser = argparse.ArgumentParser(description='Test wrapper which collects stats 
 timing_group = parser.add_mutually_exclusive_group()
 timing_group.add_argument('--timeout', dest='timeout', type=int)
 timing_group.add_argument('--until', dest='until', type=int)
+parser.add_argument('--debugger', dest='debugger', type=str)
 parser.add_argument('coresdir', type=str, help='path to cores directory')
 parser.add_argument('jobid', type=str, help='id of the test pass')
 parser.add_argument('branch', type=str, help='which branch is being tested')
@@ -20,6 +21,7 @@ parser.add_argument('dirty', type=str, help='which files are dirty.')
 parser.add_argument('testarg', type=str, nargs='+', help='test arguments')
 args = parser.parse_args()
 
+debugger = args.debugger
 coresdir = args.coresdir
 child_args = args.testarg
 test_name = child_args[0]
@@ -50,7 +52,6 @@ def move_core(dst_core, src_core):
     return dst_core
 
 def get_stack(program, core):
-    debugger = "lldb"
     if core is None:
         return None
     #TODO i need a debugger var.

--- a/regression
+++ b/regression
@@ -104,5 +104,5 @@ exit($status);
 
 sub runtest {
   my $test_name = shift @_;
-  exec "./perf.py", "--until=$timeout", $coredir, $jobid, $branch, $commit, $dirty_str, $test_name;
+  exec "./perf.py", "--until=$timeout", "--debugger=$debugger", $coredir, $jobid, $branch, $commit, $dirty_str, $test_name;
 }


### PR DESCRIPTION
Panic now builds on my raspberry pi! 

Signal definitions were broken moving to ARM. When I looked at it, I realized I could remove all the DARWIN/LINUX specialized code out of the IRQ atomic detection code.